### PR TITLE
(automated) checks for false flags against vanilla code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __MACOSX
 .thumbs
 Thumbs.db
 
-tmp/
+/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,29 @@
 language: python
 python:
   - "3.5"
+
+env:
+  matrix:
+    - MAGENTO_VERSION="1.4.2.0"
+    - MAGENTO_VERSION="1.5.1.0"
+    - MAGENTO_VERSION="1.6.2.0"
+    - MAGENTO_VERSION="1.7.0.2"
+    - MAGENTO_VERSION="1.8.1.0"
+    - MAGENTO_VERSION="1.9.2.1"
+    - MAGENTO_VERSION="1.9.2.4"
+    - MAGENTO_VERSION="1.9.3.1"
+
+matrix:
+  fast_finish: true
+
 before_install:
   - wget http://ubuntu.byte.nl/pool/hypernode/y/yara/yara_3.5.0+dfsg-2~precise1_amd64.deb
   - sudo dpkg -i yara_3.5.0+dfsg-2~precise1_amd64.deb
-script: python tools/runtests.py
+
+before_script:
+  - bash tools/travis/prepare_magento.sh
+
+script:
+  - python tools/runtests.py
+  - bash tools/travis/test_magento.sh
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ yara -r rules/all-confirmed.yar /var/www
 
 # Run tests to validate signatures and samples
 python tools/runtests.py
+
+# Verify that no false flags will be raised
+./tools/mageffcheck.sh init && ./tools/mageffcheck.sh run
 ```
 
 # Strategies for writing signatures

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -6,6 +6,7 @@ This document will briefly cover the most important aspects of the magento-malwa
 1. Installation
 2. How to use the Scanner
 3. How to add malware
+4. Test your rules
 
 # 1. Installation
 
@@ -128,3 +129,52 @@ For more information on writing rules, refer to the documentation below
 * [Writing YARA rules](http://yara.readthedocs.io/en/v3.5.0/writingrules.html)
 * [YARA in a Nutshell](http://virustotal.github.io/yara/)
 * [Example Yara Rules](https://github.com/Yara-Rules/rules)
+
+# 4. Test your rules
+
+This repository contains 2 tools and automated tests to make sure samples and fingerprints have at least one match and don't raise false flags.
+Run these before sending a pull request.
+
+## Verifying that samples and fingerprints have matches
+
+To verify this, run the following command from the project root:
+
+```bash
+python tools/runtests.py
+```
+
+## Checking for false flags against vanilla Magento code
+
+The `tools/mageffcheck.sh` bash script has a couple of commands available to get you started.
+The idea is to download and extract various vanilla Magento packages and run the YARA tests against it.
+When these tests return output, it's most likely a false flag.
+
+Running the following command will output some information:
+
+```bash
+./tools/mageffcheck.sh
+
+# OR
+
+./tools/mageffcheck.sh help
+```
+
+You can initialize the test setup by appending the `init` argument
+
+```bash
+./tools/mageffcheck.sh init
+```
+
+This will download and extract several Magento packages from the [OpenMage Magento Mirror](https://github.com/OpenMage/magento-mirror).
+
+__Note: When using an IDE__
+
+Downloading and extracting several Magento package may trigger the IDE's indexation. Due to the amount of code it may lag or even hang (for a while).
+These packages will be stored in `./tmp` make sure to _mark this directory as excluded_ before or right after running `init`.
+
+After this you could run the following to trigger the YARA tests against the vanilla code.
+
+```bash
+./tools/mageffcheck.sh run
+```
+You should expect _no output_ from running this command.

--- a/tools/mageffcheck.sh
+++ b/tools/mageffcheck.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# == Magento Security Scanner - Vanilla false flag tester
+#
+# This script can be used to test for false flags against vanilla Magento code
+#
+# = How To
+#
+# 1. use the 'init' param to download and extract Magento packages
+# 2. use the 'run' param to run the YARA tests against these packages
+#
+# = Expectation
+#
+# - There should be "no output" from the run command as these packages are considered to be clean code
+
+# Defining fancy Colors
+RED="\033[0;31m"
+YELLOW="\033[0;33m"
+GREEN="\033[0;32m"
+NONE="\033[0m"
+
+# Variables
+CMD=$1
+ARG=$2
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECTROOT=$(cd "${DIR}/.." && pwd)
+vanilladir=$(dirname "$PROJECTROOT/tmp/vanilla/.")
+
+# == Vanilla versions (https://github.com/OpenMage/magento-mirror/archive/$version)
+# You can change these to add or remove versions, see the release archive
+versions=( "1.9.3.1" "1.9.2.4" "1.7.0.2" )
+
+command_found=0
+argument_found=0
+
+# === Functions ====
+
+# == Prints help text
+function _print_help() {
+    echo "==============================================="
+    echo -e "======----  ${GREEN}Magento Security Scanner${NONE}  ----====="
+    echo "==============================================="
+    echo ""
+    echo "This script helps to setup and test your rules for false flags against vanilla Magento code."
+    echo ""
+    echo -e "${YELLOW}How To:"
+    echo ""
+    echo -e "${GREEN}1. ${NONE}Use the ${YELLOW}init ${NONE}command to download and extract vanilla versions."
+    echo -e "${GREEN}2. ${NONE}Use the ${YELLOW}run ${NONE}command to check for false flags."
+    echo ""
+    echo -e "${YELLOW}Usage${NONE}"
+    echo " command [arguments]"
+    echo ""
+    echo -e "${YELLOW}Commands:${NONE}"
+    echo -e "${GREEN}help${NONE}            Print this help text."
+    echo -e "${GREEN}init${NONE}            Downloads and extracts several vanilla Magento packages."
+    echo -e "${GREEN}run${NONE}             runs YARA against vanilla Magento packages."
+    echo -e "${YELLOW}-----------------------------------------------------------------------------------"
+    echo -e "${GREEN}test${NONE}            Shortcut to run the malware fingerprint / sample Pyton tests."
+    echo ""
+}
+
+# == Init function
+# - Creates directories
+# - Downloads and extracts magento packages
+function _init(){
+if [ ! -d "$vanilladir" ]; then
+    echo -e "${GREEN}creating $YELLOW $vanilladir $NONE"
+    mkdir -p $vanilladir
+fi
+
+echo -e "${GREEN}Vanilla packages will be extracted to: $YELLOW $vanilladir $NONE"
+
+for version in "${versions[@]}"
+do
+    echo -e "${GREEN}Downloading Magento ${YELLOW}$version${NONE}"
+    cd $vanilladir && curl -LOk  "https://github.com/OpenMage/magento-mirror/archive/${version}.zip"
+
+    if [ 0 -eq $?  ]; then
+        echo -e "${GREEN}Extracting Magento ${YELLOW}$version${NONE}"
+        unzip -qq "${version}.zip"
+        count=$(find "$vanilladir" -type f  | wc -l )
+        echo -e "${GREEN}Extracted ${count} files"
+    else
+        echo -e "${RED}Download failed! $version"
+    fi;
+done
+
+echo -e "${GREEN}Done fetching Magento packages, you can now check against this code using ${YELLOW}run."
+
+}
+
+
+# == Runs all YARA tests against vanilla Magento packages
+_runyara(){
+if [ ! -d "$vanilladir" ]; then
+    echo -e "${RED}No vanilla packages found at $YELLOW $vanilladir $NONE"
+    echo -e "${GREEN}Run the init command first, "
+    exit
+fi
+
+echo -e "${GREEN}Running YARA tests on vanilla code, ${YELLOW}should return nothing. $RED"
+cd ${PROJECTROOT} && yara -r ./rules/all-confirmed.yar ./tmp/vanilla
+}
+
+
+# == Shortcut to run Python fingerprint / sample tests
+_runtests(){
+cd $DIR && python ./runtests.py
+}
+
+
+# === Processing Input ===
+
+# Initialise input
+if [ ! -z "$CMD" ]; then
+command_found=1
+    if [ ! -z "$ARG" ]; then
+        argument_found=1
+    fi
+fi
+
+# When there's no argument or the argument = help, output help screen and exit
+if [ $command_found -eq 0 ] || [ $CMD == "help" ]; then
+    _print_help
+    exit 0
+fi
+
+# = Mapping arguments to functions
+
+if [ $CMD == "init" ]; then
+_init
+fi
+
+if [ $CMD == "run" ]; then
+_runyara
+fi
+
+if [ $CMD == "runtests" ]; then
+_runtests
+fi

--- a/tools/travis/prepare_magento.sh
+++ b/tools/travis/prepare_magento.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Magento Malware Scanner
+# Downloads and extracts a Magento version to test for false flags against the vanilla code
+
+if [ ! -z ${MAGENTO_VERSION+x} ]; then
+
+    target_directory="${SETUP_DIR:-./}${MAGENTO_VERSION}"
+
+    echo "downloading magento ${MAGENTO_VERSION}"
+
+    curl -LOk  "https://github.com/OpenMage/magento-mirror/archive/${version}.zip"
+
+    if [ 0 -eq $?  ]; then
+
+    echo "unzipping magento ${MAGENTO_VERSION}"
+
+    unzip -qq "${MAGENTO_VERSION}.zip" -d ${target_directory}
+
+    else
+        echo -e "Download failed! $version"
+
+        # not sure if i should let it fail or skip the test
+    fi;
+
+fi

--- a/tools/travis/prepare_magento.sh
+++ b/tools/travis/prepare_magento.sh
@@ -8,7 +8,7 @@ if [ ! -z ${MAGENTO_VERSION+x} ]; then
 
     echo "downloading magento ${MAGENTO_VERSION}"
 
-    curl -LOk  "https://github.com/OpenMage/magento-mirror/archive/${version}.zip"
+    curl -LOk  "https://github.com/OpenMage/magento-mirror/archive/${MAGENTO_VERSION}.zip"
 
     if [ 0 -eq $?  ]; then
 
@@ -17,7 +17,7 @@ if [ ! -z ${MAGENTO_VERSION+x} ]; then
     unzip -qq "${MAGENTO_VERSION}.zip" -d ${target_directory}
 
     else
-        echo -e "Download failed! $version"
+        echo -e "Download failed! $MAGENTO_VERSION"
 
         # not sure if i should let it fail or skip the test
     fi;

--- a/tools/travis/test_magento.sh
+++ b/tools/travis/test_magento.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Magento Malware Scanner
+#
+# Runs all YARA rules against the installed set of vanilla code
+
+if [ ! -z ${MAGENTO_VERSION+x} ]; then
+
+    target_directory="${SETUP_DIR:-./}${MAGENTO_VERSION}"
+
+    echo "Testing YARA rules against vanilla magento version ${MAGENTO_VERSION}"
+
+    if [ -d "$target_directory" ]; then # the prepare_magento.sh file should skip this when the download failed
+
+    yara -r ./rules/all-confirmed.yar ${target_directory}
+
+    fi
+
+fi

--- a/tools/travis/test_magento.sh
+++ b/tools/travis/test_magento.sh
@@ -11,8 +11,12 @@ if [ ! -z ${MAGENTO_VERSION+x} ]; then
 
     if [ -d "$target_directory" ]; then # the prepare_magento.sh file should skip this when the download failed
 
-    yara -r ./rules/all-confirmed.yar ${target_directory}
+        TEST=`yara -r ./rules/all-confirmed.yar ${target_directory}`
 
+        if [[ $TEST ]]; then
+            exit 1
+        else
+            exit 0
+        fi
     fi
-
 fi


### PR DESCRIPTION
This pull request contains additions to aid in testing rules for false flags against vanilla Magento code by downloading and extracting packages and run the tests against those packages.

**It contains**
* A way to have travis test and fail at false flags against vanilla Magento code.
* Tool to setup and test this local
* Docs

**Example travis failing and succeeding**
1. [Successful Build](https://travis-ci.org/frosit/magento-malware-scanner/builds/183806815)
2. [Failed due to false flag](https://travis-ci.org/frosit/magento-malware-scanner/builds/183807332)
3. [Successful again](https://travis-ci.org/frosit/magento-malware-scanner/builds/183808069)