### PR TITLE
Fix invalid psutil method call on darwin

### DIFF
--- a/mwscan/mwscan.py
+++ b/mwscan/mwscan.py
@@ -202,7 +202,7 @@ def main():
     args = parse_args()
 
     # don't swamp the machine
-    if psutil:
+    if psutil and sys.platform != "darwin":
         mylife = psutil.Process()
         mylife.ionice(psutil.IOPRIO_CLASS_IDLE)
 


### PR DESCRIPTION
Running this on OS X resulted in the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/mwscan", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/mwscan/mwscan.py", line 207, in main
    mylife.ionice(psutil.IOPRIO_CLASS_IDLE)
AttributeError: 'Process' object has no attribute 'ionice'
```

The documentation for ionice states that it's only available in "Linux and Windows > Vista". This check allows `mywscan` to successfully run on OS X.