### PR TITLE
Adding additional domains

### DIFF
--- a/rules/burner-domains.txt
+++ b/rules/burner-domains.txt
@@ -9,7 +9,9 @@ dnsden.biz
 ebizmart.biz
 fellsogood43.pw
 infopromo.biz
+informaer.com
 informaer.net
+informaer.org
 inst-js.su
 ip.5uu8.com
 jcloudcnd.com
@@ -48,7 +50,10 @@ web-rank.cc
 web-rank.pw
 webrank.ws
 webstat.cc
+webstats.me
 webstat-info.ws
+webstatistic.me
+webstatistic.pw
 webstatistic.tech
 web-stat.me
 web-stats.cc


### PR DESCRIPTION
Added 5 domains related to magento malware. Appear to be registered by the same actor, using the same IP subnet (85.93.5.0/24)