### PR TITLE
Remove False-positive.

### DIFF
--- a/build/all-confirmed.txt
+++ b/build/all-confirmed.txt
@@ -743,7 +743,6 @@ js\-storage\.click\/
 killall\ \-9\ \"\.basename\(\"\/usr\/bin\/host
 lastc0de\@Outlook\.com
 link\-js\.link\/
-location\.href\.indexOf\(\"(checkout|onestep|firecheckout|onestepcheckout|onepagecheckout|onepage|checkout\/onepage)\"\)
 logisticusa\.biz\/
 logzz\@eduz\.edu
 mage\-cdn\.link\/

--- a/build/all-confirmed.yar
+++ b/build/all-confirmed.yar
@@ -2770,10 +2770,6 @@ rule gate_php_js_f8d05 {
 	strings: $ = /url:\s?'https?:\/\/[^\/]{5,30}\/gate\.php\?token=\w{4,20}',/
 	condition: any of them
 }
-rule generic_payment_detection_827f9 {
-	strings: $ = /location\.href\.indexOf\(\"(checkout|onestep|firecheckout|onestepcheckout|onepagecheckout|onepage|checkout\/onepage)\"\)/
-	condition: any of them
-}
 rule generic_payment_detection_ee7c6 {
 	strings: $ = /(href\.match|RegExp)\([^)(]*(checkout|onestep|firecheckout|onestepcheckout|onepagecheckout|onepage|checkout\/onepage)\|[^)(]*\)/
 	condition: any of them

--- a/rules/frontend.txt
+++ b/rules/frontend.txt
@@ -145,7 +145,6 @@ this['eval'](this['atob']('
 
 # generic payment detection
 /(href\.match|RegExp)\([^)(]*(checkout|onestep|firecheckout|onestepcheckout|onepagecheckout|onepage|checkout\/onepage)\|[^)(]*\)/
-/location\.href\.indexOf\(\"(checkout|onestep|firecheckout|onestepcheckout|onepagecheckout|onepage|checkout\/onepage)\"\)/
 
 # +(84>20?"\x6d":"\x64")+ found @ tophatcigar.com, everstylish.com
 # regex bomb


### PR DESCRIPTION
One of our customers ran into this false-positive by serving the code:
```
if (window.location.href.indexOf("onestepcheckout") != -1) {
jQuery("#some_element").hide();
}

```

Related to PR https://github.com/gwillem/magento-malware-scanner/pull/140 