### PR TITLE
Fix false alerts

### DIFF
--- a/build/all-confirmed.txt
+++ b/build/all-confirmed.txt
@@ -844,4 +844,3 @@ xh3LL
 xx\=\"\"\.constructor\;
 youpayme\.info\/
 z\=x\['length'\]\;for\(i\=0\;i\<z\;i\+\+\)\{y\+\=String\['fromCharCode'\]\(x\['charCodeAt'\]\(i\)\-10\)
-


### PR DESCRIPTION
This reverts commit 3630d9c8ca15524d71aa27d9eeb1ac7a5a972c12.

This whitespace was causing grep to return lots of false errors.

## Download vanilla magento and prepare for quick scan

```bash
[15:31:30] lukerodgers [~/src]$ git clone --depth 1 git@github.com:openmage/magento-mirror m1.9
Cloning into 'm1.9'...
remote: Counting objects: 19333, done.
remote: Compressing objects: 100% (9357/9357), done.
remote: Total 19333 (delta 8736), reused 14750 (delta 7613), pack-reused 0
Receiving objects: 100% (19333/19333), 25.54 MiB | 2.97 MiB/s, done.
Resolving deltas: 100% (8736/8736), done.
Checking out files: 100% (14411/14411), done.
[15:31:54] lukerodgers [~/src]$ cd m1.9/
[15:31:56] lukerodgers [~/src/m1.9]$ wget git.io/mwscan.txt
URL transformed to HTTPS due to an HSTS policy
--2017-10-23 15:32:06--  https://git.io/mwscan.txt
Resolving git.io... 54.243.73.226, 54.243.115.172, 54.225.199.17, ...
Connecting to git.io|54.243.73.226|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/gwillem/magento-malware-scanner/master/build/all-confirmed.txt [following]
--2017-10-23 15:32:07--  https://raw.githubusercontent.com/gwillem/magento-malware-scanner/master/build/all-confirmed.txt
Resolving raw.githubusercontent.com... 151.101.128.133, 151.101.192.133, 151.101.64.133, ...
Connecting to raw.githubusercontent.com|151.101.128.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 56339 (55K) [text/plain]
Saving to: 'mwscan.txt'

mwscan.txt                        100%[============================================================>]  55.02K  --.-KB/s   in 0.02s

2017-10-23 15:32:08 (2.82 MB/s) - 'mwscan.txt' saved [56339/56339]
```

## Run quick scan and see lots of stuff

None of the above should be appearing

```
[15:32:16] lukerodgers [~/src/m1.9]$ grep -Erlf mwscan.txt ./
.//.gitignore
.//.htaccess
.//.htaccess.sample
.//api.php
.//app/.htaccess
.//app/bootstrap.php
.//app/code/community/Cm/RedisSession/etc/config.xml
.//app/code/community/Cm/RedisSession/Model/Session.php
.//app/code/community/Phoenix/Moneybookers/Block/Form.php
.//app/code/community/Phoenix/Moneybookers/Block/Info.php
.//app/code/community/Phoenix/Moneybookers/Block/Jsinit.php
.//app/code/community/Phoenix/Moneybookers/Block/Payment.php
.//app/code/community/Phoenix/Moneybookers/Block/Placeform.php
.//app/code/community/Phoenix/Moneybookers/Block/Redirect.php
.//app/code/community/Phoenix/Moneybookers/controllers/MoneybookersController.php
.//app/code/community/Phoenix/Moneybookers/controllers/ProcessingController.php
.//app/code/community/Phoenix/Moneybookers/etc/config.xml
.//app/code/community/Phoenix/Moneybookers/etc/system.xml
.//app/code/community/Phoenix/Moneybookers/Helper/Data.php
.//app/code/community/Phoenix/Moneybookers/Model/Abstract.php
.//app/code/community/Phoenix/Moneybookers/Model/Acc.php
.//app/code/community/Phoenix/Moneybookers/Model/Csi.php
.//app/code/community/Phoenix/Moneybookers/Model/Did.php
.......
[truncated, it goes on!]
```

### Manually patch mwscan.txt

```
[15:33:38] lukerodgers [~/src/m1.9]$ cp mwscan.txt mwscan.txt.orig
[15:33:42] lukerodgers [~/src/m1.9]$ nano mwscan.txt # remove final whitespace line
[15:33:53] lukerodgers [~/src/m1.9]$ grep -Erlf mwscan.txt ./ # this command ran for a minute with no output
^C
[15:34:10] lukerodgers [~/src/m1.9]$ diff mwscan.txt mwscan.txt.orig
846a847
>
```