### PR TITLE
Magesec URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Magento is a profitable target for hackers. Since 2015, I have identified more than 20.000 compromised stores. In most cases, malware is inserted that will a) intercept customer data, b) divert payments or c) uses your customers for cryptojacking.
 
-This project contains both a **fast scanner** to quickly find malware, and a collection of Magento **malware signatures**. They are [recommended by Magento](https://magento.com/security/best-practices/detect-malware-new-discovery-rules) and used by the [US Department of Homeland Security](https://www.dhs.gov/topic/cybersecurity), the [Magento Marketplace](https://twitter.com/jason_c_cochran/status/850043415194685441), [Magereport](https://www.magereport.com), the [Mage Security Council](https://www.magesec.org) and [many others](docs/who-is-using.md).
+This project contains both a **fast scanner** to quickly find malware, and a collection of Magento **malware signatures**. They are [recommended by Magento](https://magento.com/security/best-practices/detect-malware-new-discovery-rules) and used by the [US Department of Homeland Security](https://www.dhs.gov/topic/cybersecurity), the [Magento Marketplace](https://twitter.com/jason_c_cochran/status/850043415194685441), [Magereport](https://www.magereport.com), the [Mage Security Council](https://magesec.org) and [many others](docs/who-is-using.md).
 
 # Need help?
 


### PR DESCRIPTION
Magesec's cert does not contain a matching common name / SAN entry for www.magesec.org which causes this link to fail to load in some browsers now (Safari / Brave).