### PR TITLE
Make debian packaging work out of the box

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,16 +2,17 @@ Source: mwscan
 Maintainer: Willem de Groot <gwillem@gmail.com>
 Section: python
 Priority: optional
-# Strangely enough, if dh-python is added here, it will generate strict Python version dependencies 
-# (eg >= 2.7.5) --WdG
-Build-Depends: python-setuptools, python, debhelper (>= 9)
+Build-Depends: python, python-dev, dh-python, python-setuptools, debhelper (>= 9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/gwillem/magento-malware-scanner
 X-Python-Version: >= 2.6
 
 Package: python-mwscan
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}
+# don't use ${python:Depends} here as dh-python will replace that with a more
+# strict version constraint than we want (e.g. >= 2.7.5-5~)
+Depends: ${misc:Depends}, python:any (>= 2.6), python:any (<< 2.8),
+	python-yara, python-psutil, python-requests (>= 0.8.2)
 Description: Find malware in web documents.
  A Yara wrapper to identify malware, with support for incremental scans, extension filtering and efficient hash whitelisting.
 


### PR DESCRIPTION
If dh-python is not added as a build dependency, the Depends field will be filled with weird and incorrect values from `setup.py`'s install_requires.

However, dh-python causes ${python:Depends} to be too strict. So just get rid of that and put in the python verison Depends manually.

I tested this using cowbuilder/pdebuild for Debian Stretch as well as Ubuntu Xenial.

Also see comments in https://github.com/gwillem/magento-malware-scanner/pull/185