### PR TITLE
Update burner-domains.txt

### DIFF
--- a/rules/burner-domains.txt
+++ b/rules/burner-domains.txt
@@ -19,6 +19,7 @@ cdnanalytics.net
 cdnassels.com
 ccheckout.com
 cdn-cloud.pw
+cdn-js-42.com
 cdnbronto.com
 cdnbronto.info
 cdnmage.com
@@ -49,6 +50,7 @@ jquery-min.su
 jquery-validation.org
 jquerycdnlibrary.com
 jqueryextd.us
+jqueryexts.us
 js-cloud.com
 js-save.link
 js-stats.click


### PR DESCRIPTION
Hi, I added the following two domains hosted in NameCheap that use the same Russian logon page as other Magento malware sites (Административная панель: Войти). 

The two sites I added are: 
cdn-js-42.com
jqueryexts.us

There is already a site called jqueryextd.us so this is a similar naming convention.