### PR TITLE
moved JS_Encoded_CC_Hijack because false positive for node-forge

### DIFF
--- a/rules/custom.yar
+++ b/rules/custom.yar
@@ -7,15 +7,15 @@ HOWEVER
 Please don't! Complex Yara rules cannot be converted
 into grep patterns, and as such, the majority of people
 (who use the grep signatures) will not be able to use
-your pattern. 
+your pattern.
 
-So only add rules here that cannot be expressed as a 
+So only add rules here that cannot be expressed as a
 single literal or regex.
 
 */
 
 rule php_code_in_jpeg {
-    strings: 
+    strings:
         $jpg = { FF D8 FF E0 ?? ?? 4A 46 49 46 00 01 }
 		/*
         // https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -25,12 +25,4 @@ rule php_code_in_jpeg {
         */
         $php = "<?php"
     condition: ($jpg at 0) and $php
-}
-rule JS_Encoded_CC_Hijack {
-    strings: 
-	$a = /function \w\(\w,\s?\w,\s?\w\)/
-	$b = /\w = \(\w\s?\+\s?\w\)\s?\%\s?\w\.length/
-	$c = /\w\.charAt\(\w\)/
-	$d = /\w\(\w\(\"[\w\W\s]{1,25}\",\s?\d{1,5},\s?\d{1,5}\)/
-    condition: ($a and $b and $c) or $d
 }

--- a/rules/suspicious.yar
+++ b/rules/suspicious.yar
@@ -13,7 +13,7 @@ rule fromCharCode_in_unicode {
     condition: any of them
 }
 rule function_through_object {
-    strings: 
+    strings:
         $ = "['eval']"
         $ = "['unescape']"
         $ = "['charCodeAt']"
@@ -49,7 +49,7 @@ rule obf_base64_decode {
     condition: any of them
 }
 rule html_upload {
-    strings: 
+    strings:
         $ = "<input type='submit' name='upload' value='upload'>"
         $ = "if($_POST['upload'])"
     condition: any of them
@@ -71,4 +71,13 @@ rule eval_with_comments {
 	strings:
 		$ = /(^|\s)eval\s*\/\*.{,128}\*\/\s*\(/
 	condition: any of them
+}
+
+rule JS_Encoded_CC_Hijack {
+    strings:
+	$a = /function \w\(\w,\s?\w,\s?\w\)/
+	$b = /\w = \(\w\s?\+\s?\w\)\s?\%\s?\w\.length/
+	$c = /\w\.charAt\(\w\)/
+	$d = /\w\(\w\(\"[\w\W\s]{1,25}\",\s?\d{1,5},\s?\d{1,5}\)/
+    condition: ($a and $b and $c) or $d
 }


### PR DESCRIPTION
Moved the the rule because of false positives for the Node Module node-forge