### PR TITLE
Update trafficanalyzer.js signature

### DIFF
--- a/rules/frontend.txt
+++ b/rules/frontend.txt
@@ -30,7 +30,7 @@ RegExp("[0-9]{13,16}")
 =oQKpkyJ8dCK0lGbwNnLn42bpRXYj9GbENDft12bkBjM8V2Ypx2c8Rnbl52bw12bDlkUVVGZvNWZkZ0M85WavpGfsJXd8R1UPB1NywXZtFmb0N3box
 
 # Trafficanalyzer_js
-z=x['length'];for(i=0;i<z;i++){y+=String['fromCharCode'](x['charCodeAt'](i)-10) 
+z=x['length'];for(i=0;i<z;i++){y+=String['fromCharCode'](x['charCodeAt'](i)-
 
 # atob_js
 eval(atob(


### PR DESCRIPTION
Someone sent me a snippet of this malware, but with an eight character offset:

```
z=x['length'];for(i=0;i<z;i++){y+=String['fromCharCode'](x['charCodeAt'](i)-8)
```

Removed the offset for the signature. Feels like it is matter of time until a different integer is used

Edit: Spotted a 7 char offset as well: [publicwww](https://publicwww.com/websites/%22%3Bz%3Dx%5B%27length%27%5D%3Bfor%28i%3D0%3Bi%3Cz%3Bi%2B%2B%29%7By%2B%3DString%5B%27fromCharCode%27%5D%28x%5B%27charCodeAt%27%5D%28i%29-%22/)