### PR TITLE
Adds jquery-js.com burner domain

### DIFF
--- a/rules/burner-domains.txt
+++ b/rules/burner-domains.txt
@@ -45,6 +45,7 @@ jquery-cdnlib.com
 jquery-cloud.net
 jquery-code.su
 jquery-css.su
+jquery-js.com
 jquery-libs.su
 jquery-main.su
 jquery-min.su


### PR DESCRIPTION
jquery-js.com itself redirects to the legitimate jquery.com domain, however, the domain hosts malware at the bottom of its jquery.min.js files:

```
http://jquery-js.com/jquery.min.js
http://jquery-js.com/jquery.1.4.4.min.js
```