### PR TITLE
more exact matching for eval_post

### DIFF
--- a/rules/backend.txt
+++ b/rules/backend.txt
@@ -27,7 +27,7 @@ rb2JHaTJVdURMNlhQZ1ZlTGVjVnFobVdnMk5nbDlvbEdBQVZKRzJ1WmZUSjdVOWNwWURZYlZ0L1BtNCt
 # eval_post
 eval(base64_decode($_POST
 eval($undecode($tongji))
-eval($_POST
+/\beval\(\$_POST/
 
 # spam_mailer
 <strong>WwW.Zone-Org</strong>


### PR DESCRIPTION
Currently it matches old versions of shop4 because they use the function doubleval
see https://gitlab.jtl-software.de/jtlshop/shop4/blob/9047bec4e718aadb433b5a10bc5c02c0df326b89/classes/class.JTL-Shop.Preisverlauf.php#L153 for example