### PR TITLE
adding more magecart domains

### DIFF
--- a/rules/burner-domains.txt
+++ b/rules/burner-domains.txt
@@ -51,6 +51,7 @@ ccheckout.com
 ccvalidate.com
 cdn-ch.org
 cdn-cloud.pw
+cdn-imgcloud.com
 cdn-js-42.com
 cdn-js.link
 cdnanalytics.net
@@ -113,6 +114,7 @@ fastlscripts.com
 fbcommerse.com
 fbprotector.com
 fellsogood43.pw
+font-assets.com
 frameuserstat.com
 frashjs.com
 friend4cdn.com
@@ -140,6 +142,7 @@ informaer.org
 informaer.ws
 infostat.pw
 inst-js.su
+installw.com
 internalvaporgroup.com
 invisiblename.com
 invisiblename.pro
@@ -167,6 +170,7 @@ js-abuse.link
 js-abuse.su
 js-cdn.link
 js-cloud.com
+js-cloudhost.com
 js-link.su
 js-magic.link
 js-mod.su
@@ -377,8 +381,10 @@ webstatistic.ws
 webstats.me
 webstatvisit.com
 whitelistjs.com
+wix-cloud.com
 wpconnect.org
 wpserve.org
+ww1-filecloud.com
 x-magesecurity.com
 xmageform.com
 xmageinfo.com


### PR DESCRIPTION
References
* https://blog.malwarebytes.com/threat-analysis/2019/06/magecart-skimmers-found-on-amazon-cloudfront-cdn/