### PR TITLE
Add more skimming domains

### DIFF
--- a/rules/burner-domains.txt
+++ b/rules/burner-domains.txt
@@ -13,8 +13,10 @@ allacarts.com
 allyouwant.online
 amasty.biz
 analiticoscdn.com
+anduansury.com
 angular.club
 animalzz921.pw
+api-googles.com
 apismanagers.com
 apissystem.com
 apitstatus.com
@@ -110,6 +112,7 @@ encoderform.com
 encrypterforms.com
 encryptforms.com
 exrpesso.org
+facebookfollow.com
 fastlscripts.com
 fbcommerse.com
 fbprotector.com
@@ -133,6 +136,8 @@ googleprotectionshop.com
 googletagmanager.eu
 googletagnamager.com
 googlitagmanager.com
+gooqleadvstat.com
+gooqlemgrteg.com
 govfree.pw
 gstatlcs.com
 gtagaffilate.com
@@ -170,8 +175,10 @@ jquery-validation.org
 jquery-web.com
 jquery.su
 jquerycdnlibrary.com
+jquerycodemagento.com
 jqueryextd.us
 jqueryexts.us
+jquerystatic.com
 jquerystorage.com
 js-abuse.link
 js-abuse.su
@@ -283,6 +290,7 @@ paypallobjects.com
 privacyform.com
 privatejs.com
 privatixjs.com
+qpstasis.com
 qsxjs.com
 realtrustsafe.com
 receiverinformation.com
@@ -294,6 +302,7 @@ s3-us-west.com
 safeprivatcy.com
 safeyouform.com
 sagecdn.org
+sainester.com
 samescripts.com
 samexsame.com
 saveyoujs.com
@@ -342,6 +351,7 @@ system-backup.biz
 tcsupport241012.tk
 termlifelearned.us
 thatispersonal.com
+theresevit.com
 top-sj.link
 top5value.com
 track-js.link
@@ -404,5 +414,6 @@ xmagesecurity.com
 xn--google-analytcs-xpb.com
 xn--gstatc-7va.com
 youpayme.info
+zendesk-chart.com
 zonejs.com
 zs.mk


### PR DESCRIPTION
I came across the `jquerycodemagento.com` domain via a site of a client I just took on. Which led me to find a number of Tweets from someone who found additional domains from the same IP as well as other similar domains.

Source tweets:
* https://twitter.com/rommeljoven17/status/1169124706567544832
* https://twitter.com/rommeljoven17/status/1158657062403883008
* https://twitter.com/rommeljoven17/status/1136555260477001728